### PR TITLE
Added AU_ACN Unit Tests

### DIFF
--- a/pii_scan.py
+++ b/pii_scan.py
@@ -1,6 +1,6 @@
 """PII Scan"""
-import spacy
 import logging
+import spacy
 from presidio_analyzer import AnalyzerEngine, RecognizerRegistry, RecognizerResult
 from presidio_analyzer.predefined_recognizers import (ItDriverLicenseRecognizer,
                                                       ItVatCodeRecognizer,
@@ -10,7 +10,8 @@ from presidio_analyzer.predefined_recognizers import (ItDriverLicenseRecognizer,
                                                       EsNieRecognizer,
                                                       EsNifRecognizer,
                                                       PlPeselRecognizer,
-                                                      FiPersonalIdentityCodeRecognizer)
+                                                      FiPersonalIdentityCodeRecognizer,
+                                                      AuAcnRecognizer)
 from presidio_anonymizer import AnonymizerEngine
 
 # make sure en_core_web_lg is loaded correctly
@@ -43,6 +44,7 @@ registry.add_recognizer(EsNieRecognizer(supported_language='en'))
 registry.add_recognizer(EsNifRecognizer(supported_language='en'))
 registry.add_recognizer(PlPeselRecognizer(supported_language='en'))
 registry.add_recognizer(FiPersonalIdentityCodeRecognizer(supported_language='en'))
+registry.add_recognizer(AuAcnRecognizer(supported_language='en'))
 
 # Create an analyzer object
 # log_decision_process=True will log the decision process for debugging

--- a/test_team_dreamteam.py
+++ b/test_team_dreamteam.py
@@ -1,6 +1,6 @@
 """Unit test file for team dreamteam"""
 import unittest
-from pii_scan import analyze_text, show_aggie_pride  # noqa 
+from pii_scan import analyze_text, show_aggie_pride  # noqa
 
 
 class TestTeam_dreamteam(unittest.TestCase):
@@ -17,6 +17,30 @@ class TestTeam_dreamteam(unittest.TestCase):
 
     def test_au_acn(self):
         """Test AU_ACN functionality"""
+        pre = ['123']
+        mid = ['456']
+        suf = ['785']
+
+        # positive test cases
+        for p in pre:
+            for m in mid:
+                for s in suf:
+                    # check context score
+                    acn = '-'.join([p,m,s])
+                    print(acn)
+                    result = analyze_text('My ACN is ' + acn, ['AU_ACN'])
+                    print(result)
+                    self.assertEqual('AU_ACN', result)
+                    self.assertEqual(0.1, result[0].score)
+
+                    # checks no context
+                    result = analyze_text('My ACN is ' + acn, ['AU_ACN'])
+                    self.assertEqual('AU_ACN', result)
+                    self.assertEqual(0.01, result[0].score)
+
+        # negative test cases
+        result_invalid = analyze_text('My ACN is 123-456-789', ['AU-ACN'])
+        self.assertEqual([], result_invalid)
 
     def test_au_medicare(self):
         """Test AU_MEDICARE functionality"""

--- a/test_team_dreamteam.py
+++ b/test_team_dreamteam.py
@@ -35,29 +35,32 @@ class TestTeam_dreamteam(unittest.TestCase):
 
     def test_au_acn(self):
         """Test AU_ACN functionality"""
-        pre = ['123']
-        mid = ['456']
-        suf = ['785']
+        # 005 499 981
+        pre = ['005']
+        mid = ['499']
+        suf = ['981']
 
         # positive test cases
         for p in pre:
             for m in mid:
                 for s in suf:
                     # check context score
-                    acn = '-'.join([p,m,s])
-                    print(acn)
-                    result = analyze_text('My ACN is ' + acn, ['AU_ACN'])
+                    acn = ' '.join([p,m,s])
+                    text = 'My ACN is ' + acn
+                    print(text)
+                    result = analyze_text(text, ['AU_ACN'])
                     print(result)
-                    self.assertEqual('AU_ACN', result)
-                    self.assertEqual(0.1, result[0].score)
+                    self.assertEqual('AU_ACN', result[0].entity_type)
+                    self.assertEqual(1.0, result[0].score)
 
                     # checks no context
-                    result = analyze_text('My ACN is ' + acn, ['AU_ACN'])
-                    self.assertEqual('AU_ACN', result)
-                    self.assertEqual(0.01, result[0].score)
+                    result = analyze_text('My num is ' + acn, ['AU_ACN'])
+                    self.assertEqual('AU_ACN', result[0].entity_type)
+                    # Validation score is 1.0 even if there is no context for AU_ACN
+                    self.assertEqual(1.0, result[0].score)
 
         # negative test cases
-        result_invalid = analyze_text('My ACN is 123-456-789', ['AU-ACN'])
+        result_invalid = analyze_text('My ACN is 123-456-789', ['AU_ACN'])
         self.assertEqual([], result_invalid)
 
     def test_au_medicare(self):


### PR DESCRIPTION
An issue with AU_ACN not being a part of the registry is preventing the unit tests from completing. Adding AU_ACN to the pii_scan file under registry was our attempt to resolve these issues however the validation cannot be found because the registry still does not exist. How can this be fixed?