### PR TITLE
Added IT_VAT_CODE test cases

### DIFF
--- a/test_team_tech_bros.py
+++ b/test_team_tech_bros.py
@@ -43,6 +43,24 @@ class TestTeam_tech_bros(unittest.TestCase):
 
     def test_it_vat_code(self):
         """Test IT_VAT_CODE functionality"""
+        # testing with context
+        valid_vat = '74575451989'
+        result = analyze_text('Il mio numero di partita iva è ' + valid_vat, ['IT_VAT_CODE'])
+        print(result)
+        self.assertEqual('IT_VAT_CODE', result[0].entity_type)
+        self.assertEqual(1.0, result[0].score)
+
+        # testing without context
+        result = analyze_text('I miei valori sono ' + valid_vat, ['IT_VAT_CODE'])
+        print(result)
+        self.assertEqual('IT_VAT_CODE', result[0].entity_type)
+        self.assertEqual(1.0, result[0].score)
+
+        # negative test case
+        invalid_vat = '12348945'
+        result = analyze_text('Il mio numero di partita iva è ' + invalid_vat, ['IT_VAT_CODE'])
+        print(result)
+        self.assertListEqual([], result)
 
 
 if __name__ == '__main__':

--- a/test_team_tech_bros.py
+++ b/test_team_tech_bros.py
@@ -51,7 +51,7 @@ class TestTeam_tech_bros(unittest.TestCase):
         self.assertEqual(1.0, result[0].score)
 
         # testing without context
-        result = analyze_text('I miei valori sono ' + valid_vat, ['IT_VAT_CODE'])
+        result = analyze_text(valid_vat, ['IT_VAT_CODE'])
         print(result)
         self.assertEqual('IT_VAT_CODE', result[0].entity_type)
         self.assertEqual(1.0, result[0].score)


### PR DESCRIPTION
so far testing with and without context produces the same score regardless of the input, I am not entirely sure why but I suspect it may have to do with the checksum algorithm that is performed after pattern matching.